### PR TITLE
Add simple React frontend

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Solana Dice Game</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "solana-dice-frontend",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "@project-serum/anchor": "^0.31.1",
+    "@solana/web3.js": "^1.89.0",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
+  },
+  "devDependencies": {
+    "@types/react": "^18.2.21",
+    "@types/react-dom": "^18.2.7",
+    "@vitejs/plugin-react": "^4.2.1",
+    "typescript": "^5.3.3",
+    "vite": "^5.2.0"
+  }
+}

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,0 +1,100 @@
+import * as anchor from "@project-serum/anchor";
+import { useEffect, useState } from "react";
+import { AnchorProvider, Program, web3 } from "@project-serum/anchor";
+import idl from "./idl/solana_dice_game.json";
+
+const { SystemProgram } = web3;
+const programID = new web3.PublicKey(
+  "BkiKwAoQEogZtundzzn5buhLfntYdoiFABur66buDXMM"
+);
+
+const network = "https://api.devnet.solana.com";
+
+function getProvider() {
+  const connection = new web3.Connection(network, "processed");
+  const provider = new AnchorProvider(connection, (window as any).solana, {
+    preflightCommitment: "processed",
+  });
+  return provider;
+}
+
+export default function App() {
+  const [walletAddress, setWalletAddress] = useState<string | null>(null);
+  const [chosenNumber, setChosenNumber] = useState(1);
+  const [betAmount, setBetAmount] = useState(0.1);
+
+  useEffect(() => {
+    const provider = (window as any).solana;
+    if (provider?.isPhantom) {
+      provider.connect({ onlyIfTrusted: true }).then((res: any) => {
+        setWalletAddress(res.publicKey.toString());
+      });
+    }
+  }, []);
+
+  const connectWallet = async () => {
+    const { solana } = window as any;
+    if (solana) {
+      const response = await solana.connect();
+      setWalletAddress(response.publicKey.toString());
+    }
+  };
+
+  const placeBet = async () => {
+    const provider = getProvider();
+    const program = new Program(idl as any, programID, provider);
+
+    const [gameConfigPDA] = await web3.PublicKey.findProgramAddress(
+      [Buffer.from("game-config")],
+      programID
+    );
+
+    const lamports = betAmount * web3.LAMPORTS_PER_SOL;
+
+    await program.methods
+      .placeBet(chosenNumber, new anchor.BN(lamports))
+      .accounts({
+        gameConfig: gameConfigPDA,
+        player: provider.wallet.publicKey,
+        systemProgram: SystemProgram.programId,
+      })
+      .rpc();
+  };
+
+  return (
+    <div style={{ padding: "2rem" }}>
+      <h1>Solana Dice Game</h1>
+      {walletAddress ? (
+        <p>Wallet: {walletAddress}</p>
+      ) : (
+        <button onClick={connectWallet}>Connect Wallet</button>
+      )}
+      <div style={{ marginTop: "1rem" }}>
+        <label>
+          Choose Number (1-6):
+          <input
+            type="number"
+            min="1"
+            max="6"
+            value={chosenNumber}
+            onChange={(e) => setChosenNumber(Number(e.target.value))}
+          />
+        </label>
+      </div>
+      <div style={{ marginTop: "1rem" }}>
+        <label>
+          Bet Amount (SOL):
+          <input
+            type="number"
+            step="0.01"
+            value={betAmount}
+            onChange={(e) => setBetAmount(Number(e.target.value))}
+          />
+        </label>
+      </div>
+      <button style={{ marginTop: "1rem" }} onClick={placeBet} disabled={!walletAddress}>
+        Place Bet
+      </button>
+    </div>
+  );
+}

--- a/frontend/src/idl/solana_dice_game.json
+++ b/frontend/src/idl/solana_dice_game.json
@@ -1,0 +1,94 @@
+{
+  "version": "0.1.0",
+  "name": "solana_dice_game",
+  "instructions": [
+    {
+      "name": "initializeGame",
+      "accounts": [
+        { "name": "gameConfig", "isMut": true, "isSigner": false },
+        { "name": "admin", "isMut": true, "isSigner": true },
+        { "name": "systemProgram", "isMut": false, "isSigner": false }
+      ],
+      "args": [
+        { "name": "rewardPercentage", "type": "u64" }
+      ]
+    },
+    {
+      "name": "placeBet",
+      "accounts": [
+        { "name": "gameConfig", "isMut": true, "isSigner": false },
+        { "name": "player", "isMut": true, "isSigner": true },
+        { "name": "systemProgram", "isMut": false, "isSigner": false }
+      ],
+      "args": [
+        { "name": "chosenNumber", "type": "u8" },
+        { "name": "betAmount", "type": "u64" }
+      ]
+    },
+    {
+      "name": "updateRewardPercentage",
+      "accounts": [
+        { "name": "gameConfig", "isMut": true, "isSigner": false },
+        { "name": "admin", "isMut": true, "isSigner": true }
+      ],
+      "args": [
+        { "name": "newPercentage", "type": "u64" }
+      ]
+    },
+    {
+      "name": "pauseGame",
+      "accounts": [
+        { "name": "gameConfig", "isMut": true, "isSigner": false },
+        { "name": "admin", "isMut": true, "isSigner": true }
+      ],
+      "args": []
+    },
+    {
+      "name": "unpauseGame",
+      "accounts": [
+        { "name": "gameConfig", "isMut": true, "isSigner": false },
+        { "name": "admin", "isMut": true, "isSigner": true }
+      ],
+      "args": []
+    },
+    {
+      "name": "withdrawFunds",
+      "accounts": [
+        { "name": "gameConfig", "isMut": true, "isSigner": false },
+        { "name": "admin", "isMut": true, "isSigner": true }
+      ],
+      "args": [
+        { "name": "amount", "type": "u64" }
+      ]
+    }
+  ],
+  "accounts": [
+    {
+      "name": "GameConfig",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          { "name": "admin", "type": "publicKey" },
+          { "name": "rewardPercentage", "type": "u64" },
+          { "name": "isPaused", "type": "bool" },
+          { "name": "minBet", "type": "u64" },
+          { "name": "maxBet", "type": "u64" }
+        ]
+      }
+    }
+  ],
+  "events": [
+    {
+      "name": "BetResult",
+      "fields": [
+        { "name": "player", "type": "publicKey", "index": false },
+        { "name": "betAmount", "type": "u64", "index": false },
+        { "name": "chosenNumber", "type": "u8", "index": false },
+        { "name": "randomNumber", "type": "u8", "index": false },
+        { "name": "winAmount", "type": "u64", "index": false },
+        { "name": "won", "type": "bool", "index": false },
+        { "name": "timestamp", "type": "i64", "index": false }
+      ]
+    }
+  ]
+}

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,0 +1,9 @@
+import React from "react";
+import ReactDOM from "react-dom/client";
+import App from "./App";
+
+ReactDOM.createRoot(document.getElementById("root") as HTMLElement).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "ESNext",
+    "jsx": "react-jsx",
+    "moduleResolution": "node",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "isolatedModules": true,
+    "noEmit": true
+  },
+  "include": ["src/**/*.ts", "src/**/*.tsx"],
+  "exclude": ["node_modules"]
+}

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from "vite";
+import react from "@vitejs/plugin-react";
+
+export default defineConfig({
+  plugins: [react()],
+  server: {
+    port: 3000,
+  },
+});


### PR DESCRIPTION
## Summary
- add a `frontend` folder with a Vite + React setup
- implement minimal wallet connect and bet form
- include program IDL for use with `@project-serum/anchor`

## Testing
- `npm test` *(fails: Unknown file extension .ts)*

------
https://chatgpt.com/codex/tasks/task_e_685129ec42f08327a709ac1668c50f97