### PR TITLE
Fix mocha TS import

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "type": "module",
   "license": "ISC",
   "scripts": {
-    "test": "ANCHOR_WALLET=~/.config/solana/id.json mocha -r ts-node/register --timeout 10000 tests/**/*.ts"
+    "test": "ANCHOR_WALLET=~/.config/solana/id.json mocha --loader ./node_modules/ts-node/esm.mjs --timeout 10000 tests/**/*.ts"
   },
   "dependencies": {
     "@project-serum/anchor": "^0.31.1",

--- a/tests/solana-dice-game.ts
+++ b/tests/solana-dice-game.ts
@@ -1,6 +1,6 @@
 import * as anchor from "@project-serum/anchor";
 import { Program } from "@project-serum/anchor";
-import { SolanaDiceGame } from "../target/types/solana_dice_game";
+import { SolanaDiceGame } from "../target/types/solana_dice_game.js";
 import {
   PublicKey,
   SystemProgram,


### PR DESCRIPTION
## Summary
- use explicit path for ts-node loader
- import generated program with `.js` extension

## Testing
- `yarn test` *(fails: package not in lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_68510f1255dc832783df86346e8a7bd6